### PR TITLE
Fix link to cs-studio-core mailing list

### DIFF
--- a/index.html
+++ b/index.html
@@ -326,7 +326,7 @@
                 
                     User Level Questions: <a href="http://www.aps.anl.gov/epics/tech-talk/">http://www.aps.anl.gov/epics/tech-talk/</a>
                     <br>
-                    Developer Level Questions: <a href = "cs-studio-core@lists.sourceforge.net">cs-studio-core@lists.sourceforge.net</a>
+                    Developer Level Questions: <a href="https://sourceforge.net/p/cs-studio/mailman/cs-studio-core/">cs-studio-core@lists.sourceforge.net</a>
                     <br>
                     Report Bugs/Problems: <a href="https://github.com/ControlSystemStudio/cs-studio/issues">https://github.com/ControlSystemStudio/cs-studio/issues</a>
 


### PR DESCRIPTION
The `cs-studio-users` link (removed in d568271) was a `mailto:` link. This one is a link to the SourceForge page for the list.